### PR TITLE
added session storage saving

### DIFF
--- a/visualizer.html
+++ b/visualizer.html
@@ -605,7 +605,7 @@ function addURLParam(key, value){
 	let newParams = new URLSearchParams(window.location.search);
 }
 function deleteParam(){
-	window.history.pushState({}, document.title, window.location.pathname);
+	window.history.pushState(null, "", window.location.pathname);
 }
 { //check for '?load=....' in the URL:
 	let params = new URLSearchParams(window.location.search);
@@ -613,7 +613,7 @@ function deleteParam(){
 	if (name && !isFileEdited()) {
 		readURL(name);
 		addURLParam("edited", "true");
-
+		updateVisualizer(true);
 	} 
 }
 

--- a/visualizer.html
+++ b/visualizer.html
@@ -586,6 +586,7 @@ var file = document.getElementById("file");
 file.addEventListener('change', function(evt){
 	try {
 		readFile(file.files[0]);
+		deleteParam();
 		file.value = "";
 	} catch (e) {
 		console.log(e);
@@ -601,11 +602,10 @@ function addURLParam(key, value){
 	params.set(key, value);
 	const editedURL = window.location.pathname + "?" + params.toString();
 	history.pushState(null, "", editedURL);
-	console.log("hello")
 	let newParams = new URLSearchParams(window.location.search);
-	console.log("updated: " + newParams.get("edited"))
-	
-
+}
+function deleteParam(){
+	window.history.pushState({}, document.title, window.location.pathname);
 }
 { //check for '?load=....' in the URL:
 	let params = new URLSearchParams(window.location.search);
@@ -620,7 +620,6 @@ function addURLParam(key, value){
 function isFileEdited(){
 	let params = new URLSearchParams(window.location.search);
 	let edited = params.get("edited");
-	console.log("checking url: " + edited);
 	return edited !== null;
 
 }

--- a/visualizer.html
+++ b/visualizer.html
@@ -267,6 +267,18 @@ let editor = ace.edit("editor-text");
 //themes are available here: https://github.com/ajaxorg/ace/tree/master/lib/ace/theme
 editor.setTheme("ace/theme/tomorrow");
 editor.session.setMode("ace/mode/javascript");
+editor.getSession().on('change', function() {
+  update()
+});
+if (sessionStorage.getItem("autosave")) {
+  // Restore the contents of the text field
+  editor.setValue(sessionStorage.getItem("autosave"));
+}
+
+function update() //writes in <div> with id=output
+{
+	sessionStorage.setItem("autosave", editor.getValue());
+}
 
 var show = document.getElementById('show');
 

--- a/visualizer.html
+++ b/visualizer.html
@@ -268,14 +268,14 @@ let editor = ace.edit("editor-text");
 editor.setTheme("ace/theme/tomorrow");
 editor.session.setMode("ace/mode/javascript");
 editor.getSession().on('change', function() {
-  update()
+  saveOnEditorUpdate()
 });
+
 if (sessionStorage.getItem("autosave")) {
-  // Restore the contents of the text field
   editor.setValue(sessionStorage.getItem("autosave"));
 }
 
-function update() //writes in <div> with id=output
+function saveOnEditorUpdate()
 {
 	sessionStorage.setItem("autosave", editor.getValue());
 }

--- a/visualizer.html
+++ b/visualizer.html
@@ -443,13 +443,7 @@ compile.addEventListener('click', function() { updateVisualizer(false); } );
 let reload = document.getElementById("reload");
 let currentSource = null; //{file:file} or {url:url} or null
 reload.addEventListener('click', function() {
-	if (currentSource) {
-		if (currentSource.file) {
-			readFile(currentSource.file);
-		} else if (currentSource.url) {
-			readURL(currentSource.url);
-		}
-	}
+	location.reload();
 });
 
 
@@ -601,11 +595,34 @@ file.addEventListener('change', function(evt){
 });
 
 
+
+function addURLParam(key, value){
+	let params = new URLSearchParams(window.location.search);
+	params.set(key, value);
+	const editedURL = window.location.pathname + "?" + params.toString();
+	history.pushState(null, "", editedURL);
+	console.log("hello")
+	let newParams = new URLSearchParams(window.location.search);
+	console.log("updated: " + newParams.get("edited"))
+	
+
+}
 { //check for '?load=....' in the URL:
-	const m = document.location.search.match(/^\?load=(.+)$/);
-	if (m) {
-		readURL(m[1]);
-	}
+	let params = new URLSearchParams(window.location.search);
+	let name = params.get("load");
+	if (name && !isFileEdited()) {
+		readURL(name);
+		addURLParam("edited", "true");
+
+	} 
+}
+
+function isFileEdited(){
+	let params = new URLSearchParams(window.location.search);
+	let edited = params.get("edited");
+	console.log("checking url: " + edited);
+	return edited !== null;
+
 }
 
 </script>


### PR DESCRIPTION
## Summary of changes
- added session storage saving for code on editor code changes
## Testing
https://drive.google.com/file/d/1LJi7tSLezhvhadT4drfxtZX6kq7HZlgC/view?usp=sharing
^ video of manual testing
## issues assoicated
- #14 
- This could be revisited so that code is stored using the history API as Jim suggested. That would be a more robust solution because the user could go backwards/forwards in history on the tab and still have their code. 